### PR TITLE
Fix incorrect default height in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Reverse the image left and right. (Color at the same time)
 ```
 
 ## Height
-Change Image Size. Default value is 200.
+Change Image Size. Default value is 120.
 
 Write `&height= ` on the URL
 ```


### PR DESCRIPTION
The default height is 120.

https://github.com/kyechan99/capsule-render/blob/master/api/index.js#L10