### PR TITLE
[Feature Request] Add tegtBgColor and descColor as api parameter

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -35,8 +35,8 @@ export default (req, res) => {
   } = req.query;
   let color = req.query.color || "B897FF";
   let fontColor = req.query.fontColor;
-  let descColor = req.query.fontColor;
-  let textBgColor = "#ffffff";
+  let descColor = req.query.descColor;
+  let textBgColor = req.query.textBgColor || "#ffffff";
   let stroke = req.query.stroke || (req.query.strokeWidth ? "B897FF" : "none");
   let strokeWidth = req.query.strokeWidth || (req.query.stroke === "none" ? "0" : "1");
 
@@ -71,11 +71,9 @@ export default (req, res) => {
 
     // set 'text' - The layout changes depending on whether or not 'textBg' is used.
     let textScript = `
-    ${textBg === "true" ? Model.textBg(fontColor, fontAlign || 50, fontAlignY || 50, fontSize, text) : ""} 
+    ${textBg === "true" ? Model.textBg(textBgColor, fontAlign || 50, fontAlignY || 50, fontSize, text) : ""} 
     ${
-      textBg === "true"
-        ? checkText(text, textBgColor, fontAlign, fontAlignY, stroke, strokeWidth)
-        : checkText(text, fontColor, fontAlign, fontAlignY, stroke, strokeWidth)
+        checkText(text, fontColor, fontAlign, fontAlignY, stroke, strokeWidth)
     }`;
 
     // set 'desc' - Always have the color of 'fontColor'.

--- a/api/index.js
+++ b/api/index.js
@@ -52,7 +52,7 @@ export default (req, res) => {
       else if (color === "timeAuto" || color === "timeGradient")
         [color, fontColor, textBgColor] = generateAutoByTime(color, fontColor);
       else color = checkCustomColor(color);
-      descColor = fontColor;
+      descColor = descColor ? descColor : fontColor;
     }
 
     //- Layout --------------------------------------------------------------------------------------------------------
@@ -72,9 +72,7 @@ export default (req, res) => {
     // set 'text' - The layout changes depending on whether or not 'textBg' is used.
     let textScript = `
     ${textBg === "true" ? Model.textBg(textBgColor, fontAlign || 50, fontAlignY || 50, fontSize, text) : ""} 
-    ${
-        checkText(text, fontColor, fontAlign, fontAlignY, stroke, strokeWidth)
-    }`;
+    ${checkText(text, fontColor, fontAlign, fontAlignY, stroke, strokeWidth)}`;
 
     // set 'desc' - Always have the color of 'fontColor'.
     let descScript = `${checkDesc(desc, descColor, descAlign, descAlignY)} `;


### PR DESCRIPTION
안녕하세요! Capsule Render 정말 잘 사용하고 있습니다! 

뒤에 색상 없이 딱 이런 버튼 형태의 레이블을 서브헤더로 두고 싶었는데, textBgColor를 fontColor로 text color가 변경이 안되더라구요. 
textBgColor를 request parameter로 추가하는게 어떨까요? 그리고 DescColor도 parameter 적용하면 더 다양하게 디자인 할 수 있어서 좋을 것 같습니다! 

예시: 
![sample](https://capsule-render-theta.vercel.app/api?type=transparent&height=300&text=TextBgColor%20Sample&textBg=true&textBgColor=59BACC&fontColor=191919&desc=Only%20Use%20Text&descAlignY=75&descAlign=60&descColor=DA3B8A) 

감사합니다! 