### PR TITLE
fix: removed stroke artefacts inside letters

### DIFF
--- a/utils/render.ts
+++ b/utils/render.ts
@@ -128,6 +128,21 @@ export const getTextBg = (
         `;
 };
 
+const getTextStrokeAttrs = (
+  fontColor: string,
+  stroke: string,
+  strokeWidth: number,
+) => {
+  const hasStroke = strokeWidth > 0 && stroke !== "none";
+  const paintOrder = hasStroke ? "paint-order:stroke fill;" : "";
+
+  return {
+    style: `fill:#${fontColor};${paintOrder}`,
+    stroke: `#${stroke}`,
+    strokeWidth,
+  };
+};
+
 export const getText = (
   text?: string,
   fontColor: string = "000000",
@@ -137,6 +152,11 @@ export const getText = (
   strokeWidth: number = 0,
 ) => {
   if (!text) return "";
+  const { style, stroke: strokeColor, strokeWidth: width } = getTextStrokeAttrs(
+    fontColor,
+    stroke,
+    strokeWidth,
+  );
   const lines = text.split("-nl-");
   const alignX = Array.from(
     { length: lines.length },
@@ -154,9 +174,9 @@ export const getText = (
       x="${50}%" 
       y="${alignY[0]}%" 
       class="text" 
-      style="fill:#${fontColor};" 
-      stroke="#${stroke}" 
-      stroke-width="${strokeWidth}"
+      style="${style}" 
+      stroke="${strokeColor}" 
+      stroke-width="${width}"
     >
       ${lines
         .map(
@@ -174,7 +194,7 @@ export const getText = (
   `;
 
   // debate : adjustable text-anchor|pos-y. not only pos-x
-  return `<text text-anchor="middle" alignment-baseline="middle" x="${alignX[0]}%" y="${alignY[0]}%" class="text" style="fill:#${fontColor};" stroke="#${stroke}" stroke-width="${strokeWidth}" >${lines[0]}</text>`;
+  return `<text text-anchor="middle" alignment-baseline="middle" x="${alignX[0]}%" y="${alignY[0]}%" class="text" style="${style}" stroke="${strokeColor}" stroke-width="${width}" >${lines[0]}</text>`;
 };
 
 export const getDesc = (


### PR DESCRIPTION
Closes #126

When stroke is added and its color differs from text color the visual artifacts appear inside letters.

The fix is as follows: 
1) If stroke being set and it's positive - apply the `paint-order` rule so fill would cover the stroke and hide inner artifacts if they exist
2) extract this logic to function

Here's the result with the fix with the same config as in the `Venom` example:

<img width="1928" height="626" alt="image" src="https://github.com/user-attachments/assets/f6943590-b3a7-46e8-ab43-acdff4fd8a68" />

Artifacts outside the letter are still visible, but fixing it is impossible with native svg strokes😞 